### PR TITLE
Add a section on how to configure user/password for unity-accelerator dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ docker-compose up -d
 - Metrics reports: http://localhost:8080/metrics
 - Health page: http://localhost:8080/api/health-agent
 
+## Configuring dashboard account and password through command line
+Go into accelerator container by executing `sh` inside it and run `unity-accelerator` in folder `/agent`.
+```
+sudo docker-compose exec accelerator sh
+cd /agent
+unity-accelerator dashboard password admin
+```
+
 ## Additional Services
 
 - Grafana: http://localhost:3000/


### PR DESCRIPTION
Hi!

First of all thanks for great work! It puzzled me what was the default account/password for dashboard until I've figured there is non. Having short info on how to actually go into container and change it could be useful.

Thanks!